### PR TITLE
Weaker makie dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 julia = "1.6"
 FillArrays = "1.0"
-Makie = "0.19"
+Makie = "0.20"
 GeometryBasics = "0.4"
 Observables = "0.5"
 Statistics = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InteractiveViz"
 uuid = "d14badfc-0adb-4d57-980e-37858d990fa5"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,15 @@ version = "0.4.1"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1.6"
 FillArrays = "1.0"
-GLMakie = "0.8"
+Makie = "0.19"
 GeometryBasics = "0.4"
 Observables = "0.5"
 Statistics = "1.9"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,22 @@ This package does not aim to provide comprehensive production quality plotting. 
 
 ### Installation
 
+Install InteractiveViz.jl with one of the Makie backends that support interactivity (GLMakie or WebGLMakie).
+
 ```julia
 julia>]
-pkg> add InteractiveViz
+pkg> add InteractiveViz GLMakie
+```
+
+If more than one Makie backend is available, switch between them in the usual way.
+
+```julia
+using GLMakie
+
+GLMakie.activate!()
+
+using WGLMakie
+WGLMakie.activate!()
 ```
 
 ### Quick start
@@ -31,7 +44,7 @@ pkg> add InteractiveViz
 
 Let's start off visualizing a simple function of one variable:
 ```julia
-julia> using InteractiveViz
+julia> using InteractiveViz, GLMakie
 julia> ilines(sin, 0, 100)
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ If more than one Makie backend is available, switch between them in the usual wa
 
 ```julia
 using GLMakie
-
 GLMakie.activate!()
 
 using WGLMakie

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,6 +1,6 @@
 using GeometryBasics
 using FillArrays
-using GLMakie
+using Makie
 
 ### interface
 


### PR DESCRIPTION
Change required dependency from GLMakie to Makie.

The current dependency requirements forces users to install GLMakie regardless of whether they are using it or not, as opposed to installing the desired backend (WGLMakie for example).

The tradeoff is that users are now required to install the specific backend they want, so visualizations won't work "out of the box".