### PR TITLE
Add support for iheatmap!()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/site/
 # environment.
 Manifest.toml
 TODO
+
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 julia = "1.6"
 FillArrays = "1.0"
-Makie = "0.20"
+Makie = "0.19, 0.20"
 GeometryBasics = "0.4"
 Observables = "0.5"
 Statistics = "1.9"

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,43 +2,8 @@ using GeometryBasics
 using FillArrays
 using Makie
 
-### interface
-
-export iscatter, ilines, iheatmap
-export iscatter!, ilines!, iheatmap!
-
-iscatter(xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter(pts; kwargs...), Point2fSet(xy, nothing))
-iscatter(x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter(pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
-iscatter(g, xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter(g, pts; kwargs...), Point2fSet(xy, nothing))
-iscatter(g, x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter(g, pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
-iscatter!(xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter!(pts; kwargs...), Point2fSet(xy, nothing))
-iscatter!(x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter!(pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
-iscatter!(g, xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter!(g, pts; kwargs...), Point2fSet(xy, nothing))
-iscatter!(g, x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter!(g, pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
-
-ilines(f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines(x, y; kwargs...), Function1D(f, xmin, xmax))
-ilines(y::AbstractVector; kwargs...) = iviz((x, y) -> lines(x, y; kwargs...), Samples1D(eachindex(y), y))
-ilines(x::AbstractVector, y::AbstractVector; kwargs...) = iviz((x, y) -> lines(x, y; kwargs...), Samples1D(x, y))
-ilines(g, f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines(g, x, y; kwargs...), Function1D(f, xmin, xmax))
-ilines(g, y::AbstractVector; kwargs...) = iviz((x, y) -> lines(g, x, y; kwargs...), Samples1D(eachindex(y), y))
-ilines(g, x::AbstractVector, y::AbstractVector; kwargs...) = iviz((x, y) -> lines(g, x, y; kwargs...), Samples1D(x, y))
-ilines!(f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines!(x, y; kwargs...), Function1D(f, xmin, xmax))
-ilines!(y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(x, y; kwargs...), Samples1D(eachindex(y), y))
-ilines!(x::AbstractRange, y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(x, y; kwargs...), Samples1D(x, y))
-ilines!(g, f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines!(g, x, y; kwargs...), Function1D(f, xmin, xmax))
-ilines!(g, y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(g, x, y; kwargs...), Samples1D(eachindex(y), y))
-ilines!(g, x::AbstractRange, y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(g, x, y; kwargs...), Samples1D(x, y))
-
-iheatmap(f::Function, xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0; kwargs...) = iviz((x, y, z) -> heatmap(x, y, z; kwargs...), Function2D(f, xmin, xmax, ymin, ymax))
-iheatmap(z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(x, y, z; kwargs...), Samples2D(1:size(z, 1), 1:size(z, 2), z))
-iheatmap(x::AbstractRange, y::AbstractRange, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(x, y, z; kwargs...), Samples2D(x, y, z))
-iheatmap(g, f::Function, xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0; kwargs...) = iviz((x, y, z) -> heatmap(g, x, y, z; kwargs...), Function2D(f, xmin, xmax, ymin, ymax))
-iheatmap(g, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(g, x, y, z; kwargs...), Samples2D(1:size(z, 1), 1:size(z, 2), z))
-iheatmap(g, x::AbstractRange, y::AbstractRange, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(g, x, y, z; kwargs...), Samples2D(x, y, z))
 
 ### figure-axis-plot container
-
-export repaint
 
 struct FigureAxisPlotEx{T}
     fap::T
@@ -166,7 +131,42 @@ function iviz(f, data::Continuous2D)
     return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
+### interface
+
+iscatter(xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter(pts; kwargs...), Point2fSet(xy, nothing))
+iscatter(x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter(pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
+iscatter(g, xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter(g, pts; kwargs...), Point2fSet(xy, nothing))
+iscatter(g, x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter(g, pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
+iscatter!(xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter!(pts; kwargs...), Point2fSet(xy, nothing))
+iscatter!(x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter!(pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
+iscatter!(g, xy::AbstractVector{Point2f}; kwargs...) = iviz(pts -> scatter!(g, pts; kwargs...), Point2fSet(xy, nothing))
+iscatter!(g, x::AbstractVector, y::AbstractVector; kwargs...) = iviz(pts -> scatter!(g, pts; kwargs...), Point2fSet(Point2f.(x, y), nothing))
+
+ilines(f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines(x, y; kwargs...), Function1D(f, xmin, xmax))
+ilines(y::AbstractVector; kwargs...) = iviz((x, y) -> lines(x, y; kwargs...), Samples1D(eachindex(y), y))
+ilines(x::AbstractVector, y::AbstractVector; kwargs...) = iviz((x, y) -> lines(x, y; kwargs...), Samples1D(x, y))
+ilines(g, f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines(g, x, y; kwargs...), Function1D(f, xmin, xmax))
+ilines(g, y::AbstractVector; kwargs...) = iviz((x, y) -> lines(g, x, y; kwargs...), Samples1D(eachindex(y), y))
+ilines(g, x::AbstractVector, y::AbstractVector; kwargs...) = iviz((x, y) -> lines(g, x, y; kwargs...), Samples1D(x, y))
+ilines!(f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines!(x, y; kwargs...), Function1D(f, xmin, xmax))
+ilines!(y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(x, y; kwargs...), Samples1D(eachindex(y), y))
+ilines!(x::AbstractRange, y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(x, y; kwargs...), Samples1D(x, y))
+ilines!(g, f::Function, xmin=0.0, xmax=1.0; kwargs...) = iviz((x, y) -> lines!(g, x, y; kwargs...), Function1D(f, xmin, xmax))
+ilines!(g, y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(g, x, y; kwargs...), Samples1D(eachindex(y), y))
+ilines!(g, x::AbstractRange, y::AbstractVector; kwargs...) = iviz((x, y) -> lines!(g, x, y; kwargs...), Samples1D(x, y))
+
+iheatmap(f::Function, xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0; kwargs...) = iviz((x, y, z) -> heatmap(x, y, z; kwargs...), Function2D(f, xmin, xmax, ymin, ymax))
+iheatmap(z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(x, y, z; kwargs...), Samples2D(1:size(z, 1), 1:size(z, 2), z))
+iheatmap(x::AbstractRange, y::AbstractRange, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(x, y, z; kwargs...), Samples2D(x, y, z))
+iheatmap(g, f::Function, xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0; kwargs...) = iviz((x, y, z) -> heatmap(g, x, y, z; kwargs...), Function2D(f, xmin, xmax, ymin, ymax))
+iheatmap(g, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(g, x, y, z; kwargs...), Samples2D(1:size(z, 1), 1:size(z, 2), z))
+iheatmap(g, x::AbstractRange, y::AbstractRange, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap(g, x, y, z; kwargs...), Samples2D(x, y, z))
+
 iheatmap!(g::FigureAxisPlotEx, f::Function, xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Function2D(f, xmin, xmax, ymin, ymax))
 iheatmap!(g::FigureAxisPlotEx, x::AbstractRange, y::AbstractRange, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Samples2D(x, y, z))
 iheatmap!(g::Axis, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g, x, y, z; kwargs...), Samples2D(1:size(z, 1), 1:size(z, 2), z))
 iheatmap!(g::FigureAxisPlotEx, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Samples2D(1:size(z, 1), 1:size(z, 2), z))
+
+export iscatter, ilines, iheatmap
+export iscatter!, ilines!, iheatmap!
+export repaint

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -148,3 +148,7 @@ function iviz(f, data::Continuous2D)
   onany(update, resolution, axislimits)
   FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
+
+
+iheatmap!(g::Axis, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g, x, y, z; kwargs...), Samples2D(1:size(z,1), 1:size(z,2), z))
+iheatmap!(g::FigureAxisPlotEx, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Samples2D(1:size(z,1), 1:size(z,2), z))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -91,7 +91,13 @@ function iviz(f, data::PointSet)
   resolution = current_axis().scene.camera.resolution
   axislimits = current_axis().finallimits
   update(resolution[], axislimits[])
-  onany(update, resolution, axislimits)
+
+  t = Timer(x -> x, 0.1)
+  onany(resolution, axislimits) do res, axlimits
+    close(t)
+    t = Timer(x -> update(res, axlimits), 0.4)
+  end
+
   FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
@@ -116,7 +122,12 @@ function iviz(f, data::Continuous1D)
   resolution = current_axis().scene.camera.resolution
   axislimits = current_axis().finallimits
   update(resolution[], axislimits[])
-  onany(update, resolution, axislimits)
+  # onany(update, resolution, axislimits)
+  t = Timer(x -> x, 0.1)
+  onany(resolution, axislimits) do res, axlimits
+    close(t)
+    t = Timer(x -> update(res, axlimits), 0.4)
+  end
   FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
@@ -145,10 +156,16 @@ function iviz(f, data::Continuous2D)
   resolution = current_axis().scene.camera.resolution
   axislimits = current_axis().finallimits
   update(resolution[], axislimits[])
-  onany(update, resolution, axislimits)
+  # onany(update, resolution, axislimits)
+  t = Timer(x -> x, 0.1)
+  onany(resolution, axislimits) do res, axlimits
+    close(t)
+    t = Timer(x -> update(res, axlimits), 0.4)
+  end
   FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
-
+iheatmap!(g::FigureAxisPlotEx, f::Function, xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Function2D(f, xmin, xmax, ymin, ymax))
+iheatmap!(g::FigureAxisPlotEx, x::AbstractRange, y::AbstractRange, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Samples2D(x, y, z))
 iheatmap!(g::Axis, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g, x, y, z; kwargs...), Samples2D(1:size(z,1), 1:size(z,2), z))
 iheatmap!(g::FigureAxisPlotEx, z::AbstractMatrix; kwargs...) = iviz((x, y, z) -> heatmap!(g.axis, x, y, z; kwargs...), Samples2D(1:size(z,1), 1:size(z,2), z))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -7,7 +7,7 @@ using Makie
 struct FigureAxisPlotEx{T}
   fap::T
   update::Function
-  params::Union{Nothing, Dict{Symbol, Any}}
+  params::Union{Nothing,Dict{Symbol,Any}}
 end
 
 function Base.getproperty(fapd::FigureAxisPlotEx, sym::Symbol)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -2,32 +2,31 @@ using GeometryBasics
 using FillArrays
 using Makie
 
-
 ### figure-axis-plot container
 
 struct FigureAxisPlotEx{T}
-    fap::T
-    update::Function
-    params::Union{Nothing, Dict{Symbol, Any}}
+  fap::T
+  update::Function
+  params::Union{Nothing, Dict{Symbol, Any}}
 end
 
 function Base.getproperty(fapd::FigureAxisPlotEx, sym::Symbol)
-    sym === :figure && return fapd.fap.figure
-    sym === :axis && return fapd.fap.axis
-    sym === :plot && return fapd.fap.plot
-    return getfield(fapd, sym)
+  sym === :figure && return fapd.fap.figure
+  sym === :axis && return fapd.fap.axis
+  sym === :plot && return fapd.fap.plot
+  return getfield(fapd, sym)
 end
 
 Base.display(fapd::FigureAxisPlotEx; kwargs...) = display(fapd.fap; kwargs...)
 Base.display(screen::MakieScreen, fapd::FigureAxisPlotEx; kwargs...) = display(screen, fapd.fap; kwargs...)
 
 function Base.show(io::IO, fapd::FigureAxisPlotEx)
-    fapd.fap isa Makie.FigureAxisPlot && display(fapd.fap)
-    return show(io, fapd.fap)
+  fapd.fap isa Makie.FigureAxisPlot && display(fapd.fap)
+  return show(io, fapd.fap)
 end
 
 """
-    repaint(fapd::FigureAxisPlotEx)
+  repaint(fapd::FigureAxisPlotEx)
 
 Repaint a figure to update data that might have changed in the data source.
 """
@@ -40,116 +39,115 @@ repaint(fapd::FigureAxisPlotEx) = fapd.update()
 # updates, as the scene is redrawn for every movement causing image tearing.
 # Instead, we artificially limit the number of refreshes that occur.
 
-
 function iviz(f, data::PointSet)
-    lims = limits(data)
-    xrange = range(lims[1], lims[2]; length=2)
-    yrange = range(lims[3], lims[4]; length=2)
+  lims = limits(data)
+  xrange = range(lims[1], lims[2]; length=2)
+  yrange = range(lims[3], lims[4]; length=2)
+  qdata = sample(data, xrange, yrange)
+  pts = Observable(qdata.points)
+  fap = f(pts)
+  if current_axis().limits[] == (nothing, nothing)
+    xlims!(current_axis(), lims[1], lims[2])
+    ylims!(current_axis(), lims[3], lims[4])
+  end
+
+  reset_limits!(current_axis())
+
+  function update(res, lims)
+    xrange = range(lims.origin[1], lims.origin[1] + lims.widths[1]; length=round(Int, res[1]))
+    yrange = range(lims.origin[2], lims.origin[2] + lims.widths[2]; length=round(Int, res[2]))
     qdata = sample(data, xrange, yrange)
-    pts = Observable(qdata.points)
-    fap = f(pts)
-    if current_axis().limits[] == (nothing, nothing)
-        xlims!(current_axis(), lims[1], lims[2])
-        ylims!(current_axis(), lims[3], lims[4])
+    return pts[] = qdata.points
+  end
+
+  resolution = current_axis().scene.camera.resolution
+  axislimits = current_axis().finallimits
+  update(resolution[], axislimits[])
+
+  onany(resolution, axislimits) do res, axlimits
+    if @isdefined(redraw_limit)
+      close(redraw_limit)
     end
+    redraw_limit = Timer(x -> update(res, axlimits), 0.1)
+  end
 
-    reset_limits!(current_axis())
-
-    function update(res, lims)
-        xrange = range(lims.origin[1], lims.origin[1] + lims.widths[1]; length=round(Int, res[1]))
-        yrange = range(lims.origin[2], lims.origin[2] + lims.widths[2]; length=round(Int, res[2]))
-        qdata = sample(data, xrange, yrange)
-        return pts[] = qdata.points
-    end
-
-    resolution = current_axis().scene.camera.resolution
-    axislimits = current_axis().finallimits
-    update(resolution[], axislimits[])
-
-    onany(resolution, axislimits) do res, axlimits
-        if @isdefined(redraw_limit)
-            close(redraw_limit)
-        end
-        redraw_limit = Timer(x -> update(res, axlimits), 0.1)
-    end
-
-    return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
+  return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
 function iviz(f, data::Continuous1D)
-    lims = limits(data)
-    r = range(lims[1], lims[2]; length=2)
-    qdata = sample(data, r, nothing)
-    x = Observable(qdata.x)
-    y = Observable(qdata.y)
-    fap = f(x, y)
+  lims = limits(data)
+  r = range(lims[1], lims[2]; length=2)
+  qdata = sample(data, r, nothing)
+  x = Observable(qdata.x)
+  y = Observable(qdata.y)
+  fap = f(x, y)
 
-    if current_axis().limits[] == (nothing, nothing)
-        xlims!(current_axis(), lims[1], lims[2])
+  if current_axis().limits[] == (nothing, nothing)
+    xlims!(current_axis(), lims[1], lims[2])
+  end
+
+  reset_limits!(current_axis())
+
+  function update(res, lims)
+    xrange = range(lims.origin[1], lims.origin[1] + lims.widths[1]; length=round(Int, res[1]))
+    yrange = range(lims.origin[2], lims.origin[2] + lims.widths[2]; length=round(Int, res[2]))
+    qdata = sample(data, xrange, yrange)
+    x.val = qdata.x
+    return y[] = qdata.y
+  end
+
+  resolution = current_axis().scene.camera.resolution
+  axislimits = current_axis().finallimits
+  update(resolution[], axislimits[])
+
+  onany(resolution, axislimits) do res, axlimits
+    if @isdefined(redraw_limit)
+      close(redraw_limit)
     end
+    redraw_limit = Timer(x -> update(res, axlimits), 0.1)
+  end
 
-    reset_limits!(current_axis())
-
-    function update(res, lims)
-        xrange = range(lims.origin[1], lims.origin[1] + lims.widths[1]; length=round(Int, res[1]))
-        yrange = range(lims.origin[2], lims.origin[2] + lims.widths[2]; length=round(Int, res[2]))
-        qdata = sample(data, xrange, yrange)
-        x.val = qdata.x
-        return y[] = qdata.y
-    end
-
-    resolution = current_axis().scene.camera.resolution
-    axislimits = current_axis().finallimits
-    update(resolution[], axislimits[])
-
-    onany(resolution, axislimits) do res, axlimits
-        if @isdefined(redraw_limit)
-            close(redraw_limit)
-        end
-        redraw_limit = Timer(x -> update(res, axlimits), 0.1)
-    end
-
-    return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
+  return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
 function iviz(f, data::Continuous2D)
-    lims = limits(data)
-    rx = range(lims[1], lims[2]; length=2)
-    ry = range(lims[3], lims[4]; length=2)
-    qdata = sample(data, rx, ry)
-    x = Observable(qdata.x)
-    y = Observable(qdata.y)
-    z = Observable(qdata.z)
-    fap = f(x, y, z)
+  lims = limits(data)
+  rx = range(lims[1], lims[2]; length=2)
+  ry = range(lims[3], lims[4]; length=2)
+  qdata = sample(data, rx, ry)
+  x = Observable(qdata.x)
+  y = Observable(qdata.y)
+  z = Observable(qdata.z)
+  fap = f(x, y, z)
 
-    if current_axis().limits[] == (nothing, nothing)
-        xlims!(current_axis(), lims[1], lims[2])
-        ylims!(current_axis(), lims[3], lims[4])
+  if current_axis().limits[] == (nothing, nothing)
+    xlims!(current_axis(), lims[1], lims[2])
+    ylims!(current_axis(), lims[3], lims[4])
+  end
+
+  reset_limits!(current_axis())
+
+  function update(res, lims)
+    xrange = range(lims.origin[1], lims.origin[1] + lims.widths[1]; length=round(Int, res[1]))
+    yrange = range(lims.origin[2], lims.origin[2] + lims.widths[2]; length=round(Int, res[2]))
+    qdata = sample(data, xrange, yrange)
+    x.val = qdata.x
+    y.val = qdata.y
+    return z[] = qdata.z
+  end
+
+  resolution = current_axis().scene.camera.resolution
+  axislimits = current_axis().finallimits
+  update(resolution[], axislimits[])
+
+  onany(resolution, axislimits) do res, axlimits
+    if @isdefined(redraw_limit)
+      close(redraw_limit)
     end
+    redraw_limit = Timer(x -> update(res, axlimits), 0.1)
+  end
 
-    reset_limits!(current_axis())
-
-    function update(res, lims)
-        xrange = range(lims.origin[1], lims.origin[1] + lims.widths[1]; length=round(Int, res[1]))
-        yrange = range(lims.origin[2], lims.origin[2] + lims.widths[2]; length=round(Int, res[2]))
-        qdata = sample(data, xrange, yrange)
-        x.val = qdata.x
-        y.val = qdata.y
-        return z[] = qdata.z
-    end
-
-    resolution = current_axis().scene.camera.resolution
-    axislimits = current_axis().finallimits
-    update(resolution[], axislimits[])
-
-    onany(resolution, axislimits) do res, axlimits
-        if @isdefined(redraw_limit)
-            close(redraw_limit)
-        end
-        redraw_limit = Timer(x -> update(res, axlimits), 0.1)
-    end
-
-    return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
+  return FigureAxisPlotEx(fap, () -> update(resolution[], axislimits[]), nothing)
 end
 
 ### interface


### PR DESCRIPTION
Add support for overlaying heatmaps on top of each other (adding to an existing axis).
I've also reorganised the code as discussed in https://github.com/org-arl/InteractiveViz.jl/issues/22#issuecomment-1825531026

Closes #24 

May close #22

There are some issues - occasionally the image will tear when panning/zooming, but not sure what causes it. It may be a Makie issue.

Example using WGLMakie:

```julia
using WGLMakie
using InteractiveViz
using InteractiveViz.Demo

WGLMakie.activate!(; framerate=20)

# Example using a function
# iheatmap(mandelbrot, -2, 0.66, -1, 1)

# Example using a large in-memory array
f = iheatmap(zeros(10_000, 10_000))
iheatmap!(f, rand(10_000, 10_000); alpha=0.1)

f
```

I have not tested with a disk-based array/matrix - hypothetically it should work.


Note: Every now and then, a warning will be raised. 

```julia
Error in window event callback
exception =

All non scalars need same length, Found lengths for each argument: (5, 3, 1), (Vector{Makie.GlyphCollection}, Vector{Point{3, Float32}}, Quaternion{Float64})
```

The cause of this is already known https://github.com/MakieOrg/Makie.jl/issues/2473 and is not caused by/related to the changes in this PR.